### PR TITLE
🎸 Add text chunking utility using tiktoken

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "dotenv": "^17.2.2",
     "openai": "^5.23.1",
+    "tiktoken": "^1.0.22",
     "typescript": "^5.9.2",
     "weaviate-client": "^3.9.0"
   },

--- a/src/chunker.ts
+++ b/src/chunker.ts
@@ -1,0 +1,24 @@
+import { encoding_for_model, Tiktoken, TiktokenModel } from "tiktoken";
+
+// Split text into chunks based on token limits
+// Needed because embeddings have a max token/character limit
+export function chunkTextByTokens(
+    text: string,
+    maxTokens: number = 8191,
+    model: TiktokenModel = "text-embedding-3-large"
+): string[] {
+    const encoder: Tiktoken = encoding_for_model(model);
+    const tokens: Uint32Array = encoder.encode(text);
+
+    const chunks: string[] = [];
+
+    for (let i = 0; i < tokens.length; i += maxTokens) {
+        const tokenSlice: Uint32Array<ArrayBuffer> = tokens.slice(i, i + maxTokens); // stays Uint32Array
+        const decoded: Uint8Array = encoder.decode(tokenSlice);
+        // Turn Uint8Array back into JS string
+        chunks.push(new TextDecoder().decode(decoded));
+    }
+
+    encoder.free(); // free native memory from WASM
+    return chunks;
+}

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -1,3 +1,4 @@
+import {chunkTextByTokens} from '../chunker.js'
 import weaviateClient from "../weaviateClient.js";
 import {getEmbedding} from '../embed.js'
 import '../config.js';
@@ -5,3 +6,5 @@ import '../config.js';
 console.log(await weaviateClient.isReady());
 
 console.log(await getEmbedding("test"));
+
+console.log(chunkTextByTokens("test"));

--- a/yarn.lock
+++ b/yarn.lock
@@ -258,6 +258,11 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
+tiktoken@^1.0.22:
+  version "1.0.22"
+  resolved "https://registry.yarnpkg.com/tiktoken/-/tiktoken-1.0.22.tgz#a6c674839228bb88f32dfe646dff47193762f7d3"
+  integrity sha512-PKvy1rVF1RibfF3JlXBSP0Jrcw2uq3yXdgcEXtKTYn3QJ/cBRBHDnrJ5jHky+MENZ6DIPwNUGWpkVx+7joCpNA==
+
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"


### PR DESCRIPTION
# 🎸 Add text chunking utility using tiktoken

Introduced a tokenizer-based chunking helper to split large text into safe segments for embeddings or model input.

---

## ✅ Changes

- [x] `feat`: 🎸 Add `tiktoken` dependency in `package.json`
- [x] `feat`: 🎸 Create `src/chunker.ts`  
  - Added `chunkTextByTokens(text, maxTokens, model)`  
  - Uses `tiktoken` to encode and decode text into manageable chunks  
  - Frees WASM memory (`encoder.free()`) after use  
- [x] `test`: 🧪 Update `src/test/test.ts`  
  - Imported and logged `chunkTextByTokens("test")` for validation  
  - Ensured embedding + chunking utilities can be run together  

---

## 🛠 Why

- Embedding models have strict token limits (~8k for `text-embedding-3-large`)  
- Chunking enables safe preprocessing of long documents without truncation  
- Provides reusable utility for future RAG and vector search features  